### PR TITLE
Fix bug in which we could not insert images or links using the editor

### DIFF
--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -278,7 +278,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
+                    self.editor.currentView.element.focus({});
                     caretBookmark = self.editor.composer.selection.getBookmark();
                     insertImageModal.appendTo('body').modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
@@ -340,7 +340,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
+                    self.editor.currentView.element.focus({});
                     caretBookmark = self.editor.composer.selection.getBookmark();
                     insertLinkModal.appendTo('body').modal('show');
                     insertLinkModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -496,7 +496,7 @@
                 target: "Open link in new window"
             },
             image: {
-                insert: "Insert image",
+                insert: "Insert image URL",
                 cancel: "Cancel"
             },
             html: {

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -56,7 +56,7 @@
                       "<h3 class='modal-title'>" + locale.link.insert + "</h3>" +
                     "</div>" +
                     "<div class='modal-body'>" +
-                      "<input value='http://' class='bootstrap-wysihtml5-insert-link-url form-control'>" +
+                      "<input placeholder='http://' class='bootstrap-wysihtml5-insert-link-url form-control'>" +
                       "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target' checked>" + locale.link.target + "</label>" +
                     "</div>" +
                     "<div class='modal-footer'>" +
@@ -81,7 +81,7 @@
                       "<h3 class='modal-title'>" + locale.image.insert + "</h3>" +
                     "</div>" +
                     "<div class='modal-body'>" +
-                      "<input value='http://' class='bootstrap-wysihtml5-insert-image-url form-control'>" +
+                      "<input placeholder='http://link-to-your-image.png' class='bootstrap-wysihtml5-insert-image-url form-control'>" +
                     "</div>" +
                     "<div class='modal-footer'>" +
                       "<a href='#' class='btn btn-default' data-dismiss='modal'>" + locale.image.cancel + "</a>" +

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -270,7 +270,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
+                    self.editor.currentView.element.focus({});
                     caretBookmark = self.editor.composer.selection.getBookmark();
                     insertImageModal.appendTo('body').modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
@@ -332,7 +332,7 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
+                    self.editor.currentView.element.focus({});
                     caretBookmark = self.editor.composer.selection.getBookmark();
                     insertLinkModal.appendTo('body').modal('show');
                     insertLinkModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -54,7 +54,7 @@
                   "<h3>" + locale.link.insert + "</h3>" +
                 "</div>" +
                 "<div class='modal-body'>" +
-                  "<input value='http://' class='bootstrap-wysihtml5-insert-link-url input-xlarge'>" +
+                  "<input placeholder='http://' class='bootstrap-wysihtml5-insert-link-url input-xlarge'>" +
                   "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target' checked>" + locale.link.target + "</label>" +
                 "</div>" +
                 "<div class='modal-footer'>" +
@@ -75,7 +75,7 @@
                   "<h3>" + locale.image.insert + "</h3>" +
                 "</div>" +
                 "<div class='modal-body'>" +
-                  "<input value='http://' class='bootstrap-wysihtml5-insert-image-url input-xlarge'>" +
+                  "<input placeholder='http://link-to-your-image.png' class='bootstrap-wysihtml5-insert-image-url input-xlarge'>" +
                 "</div>" +
                 "<div class='modal-footer'>" +
                   "<a href='#' class='btn' data-dismiss='modal'>" + locale.image.cancel + "</a>" +

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
@@ -9136,7 +9136,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
         });
 
         dialog.observe("cancel", function() {
-          that.editor.focus(false);
+          that.editor.focus({});
           that.editor.fire("cancel:dialog", { command: command, dialogContainer: dialogElement, commandLink: link });
         });
       }
@@ -9166,7 +9166,7 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
 
     _execCommand: function(command, commandValue) {
       // Make sure that composer is focussed (false => don't move caret to the end)
-      this.editor.focus(false);
+      this.editor.focus({});
 
       this.composer.commands.exec(command, commandValue);
       this._updateLinkStates();


### PR DESCRIPTION
## Problem
Editing description to insert external link and images is not working on Teespring.

### Steps to reproduce
1. Go to the listing page in your seller dashboard.
2. Find any listing (created in Composer or Launcher) and click on the "pencil" icon for "edit". (ie: https://teespring.com/campaigns/72696073/edit)
3. In this view, try to add in a hyperlink or an image by clicking on the buttons.

#### Expected behavior
- You are able to add images and hyperlinks through our description tool editor

#### Actual behavior
- The buttons do not respond, and you are not able to add images or hyperlinks through listing edits or Admin campaign pages.

## Found issue
When we click on buttons "insert link" or "insert image", the following JS error was raised:
`Uncaught TypeError: Failed to execute 'focus' on 'HTMLElement': parameter 1 ('options') is not an object.`.

This was a known issue, that was fixed in newer versions of the `bootstrap-wysihtml5` gem (see: https://github.com/jhollingworth/bootstrap-wysihtml5/issues/391). Currently, we are using a fork from the `0.3.1.24` version, and the latest version of the original gem is `0.3.3.8`

## Solution
As we on Teespring are using a fork of that gem, upgrading the gem is not direct. Also, I tried to upgrade the gem locally (using the original gem instead of the fork), but there were a bunch of errors during upgrade that we'd need to solve.

So, I decided to solve the problem manually on our fork of the gem.
The problem was solved by replacing `element.focus(false)` calls with `element.focus({})`, because the `focus` function expects an object as its argument (see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus and https://github.com/jhollingworth/bootstrap-wysihtml5/issues/391#issuecomment-373053219).

## Additional changes
While testing this, @helenlam requested the following:
- Change the text 'Insert image' to 'Insert image URL'.
- Make `'http://'` a placeholder, instead of the actual initial value of the fields.

Those changes are also included in this PR, in separate commits.

## Link to ticket
https://www.pivotaltracker.com/story/show/162432786
